### PR TITLE
Display content based on auth

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -14,7 +14,7 @@
         <!-- About, Contact, Welcome -->
       </header>
 
-      <nav ng-if="!auth.isAuthed()" ng-include="'templates/auth.html'">
+      <nav ng-include="'templates/auth.html'">
         <!-- show Login / Register links and forms if user not logged in -->
       </nav>
 

--- a/app/index.html
+++ b/app/index.html
@@ -14,7 +14,7 @@
         <!-- About, Contact, Welcome -->
       </header>
 
-      <nav ng-include="'templates/auth.html'">
+      <nav ng-if="!auth.isAuthed()" ng-include="'templates/auth.html'">
         <!-- show Login / Register links and forms if user not logged in -->
       </nav>
 

--- a/app/index.html
+++ b/app/index.html
@@ -7,20 +7,26 @@
   <link href='http://fonts.googleapis.com/css?family=Open+Sans' rel='stylesheet' type='text/css'>
 </head>
 <body ng-controller="AuthController as auth">
-    <!-- Note need to change the display based upon whether the user is logged in -->
 
-    <!-- When signed in? -->
     <div class="grid-container outline">
 
-      <header ng-include="'templates/header.html'"></header>
-      <nav ng-include="'templates/auth-nav.html'"></nav>
+      <header ng-include="'templates/header.html'">
+        <!-- About, Contact, Welcome -->
+      </header>
 
-      <div ng-if="auth.isAuthed()" ng-include="'templates/rvb-nav-bar.html'"></div>
-      <nav ng-if="!auth.isAuthed()" ng-include="'templates/auth.html'"></nav>
+      <nav ng-if="!auth.isAuthed()" ng-include="'templates/auth.html'">
+        <!-- show Login / Register links and forms if user not logged in -->
+      </nav>
+
+      <div ng-if="auth.isAuthed()" ng-include="'templates/rvb-nav-bar.html'">
+        <!-- show tabbed panel navigation if user is logged in -->
+      </div>
 
       <div class="row" >
+        <div ng-if="auth.isAuthed()" ng-view>
+        <!-- show main page content if user is logged in -->
         <!-- Templates accessed by router render here -->
-        <div ng-if="auth.isAuthed()" ng-view></div>
+        </div>
       </div>
 
       </div>

--- a/app/javascripts/controllers/auth-controller.js
+++ b/app/javascripts/controllers/auth-controller.js
@@ -1,6 +1,6 @@
 angular.module("JHO")
-    .controller('AuthController', ['user', 'auth', '$window',
-        function AuthController(user, auth, $window) {
+    .controller('AuthController', ['user', 'auth', '$window', '$location',
+        function AuthController(user, auth, $window, $location) {
             var self = this;
             console.log("in AuthController")
 
@@ -12,6 +12,10 @@ angular.module("JHO")
                     console.log("server error / bad request: ", res);
                 }
                 self.message = res.data;
+            }
+
+            self.toBoard = function($location) {
+                $location.path('/board').replace();
             }
 
             self.login = function(returningUser) {

--- a/app/javascripts/controllers/auth-controller.js
+++ b/app/javascripts/controllers/auth-controller.js
@@ -4,18 +4,27 @@ angular.module("JHO")
             var self = this;
             console.log("in AuthController")
 
+            function sendToBoard() {
+                $window.location.href = '#/board';
+                $window.location.href;
+            }
+
+            function sendToAuth() {
+                $window.location.href = '#/auth';
+                $window.location.href;
+            }
+
             function handleRequest(res) {
+                console.log("handleRequest response is:", res)
                 var token = res.data ? res.data.token : null;
                 if (token) {
                     console.log('JWT:', token);
+                    self.message = res.data;
+                    sendToBoard();
                 } else {
-                    console.log("server error / bad request: ", res);
+                    console.log("handleRequest server error / bad request: ", res);
+                    sendToAuth();
                 }
-                self.message = res.data;
-            }
-
-            self.toBoard = function($location) {
-                $location.path('/board').replace();
             }
 
             self.login = function(returningUser) {

--- a/app/javascripts/routes.js
+++ b/app/javascripts/routes.js
@@ -12,21 +12,36 @@ angular.module("JHO")
                 redirectTo: '/auth'
             })
 
-            // example route
-            // .when('/notes', {
-            //     templateUrl: "assets/templates/notes/index.html",
-            //     controller: "NotesIndexController"
-            // })
-
             .when('/logout', {
                 redirectTo: '/auth'
             })
-
+            // Auth view
             .when('/auth', {
                 templateUrl: "templates/auth.html",
                 controller: "AuthController",
                 controllerAs: 'auth'
             })
+
+            .when('/board', {
+                templateUrl: 'templates/panels/board/board-index.html',
+                activetab: 'board'
+            })
+
+            .when('/today', {
+                templateUrl: 'templates/panels/today/today-index.html',
+                activetab: 'today'
+            })
+
+            .when('/stats', {
+                templateUrl: 'templates/panels/stats/stats-index.html',
+                activetab: 'toda'
+            })
+
+            .when('/tips', {
+                templateUrl: 'templates/panels/tips/tips-index.html',
+                activetab: 'board'
+            })
+
             // Welcome view
             .when('/welcome', {
                 templateUrl: "templates/welcome.html",
@@ -71,23 +86,6 @@ angular.module("JHO")
                     }
                 ]
             })
-
-            .when('/board', {
-                templateUrl: 'templates/panels/board/board-index.html',
-                activetab: 'board'
-            })
-                .when('/today', {
-                    templateUrl: 'templates/panels/today/today-index.html',
-                    activetab: 'today'
-                })
-                .when('/stats', {
-                    templateUrl: 'templates/panels/stats/stats-index.html',
-                    activetab: 'toda'
-                })
-                .when('/tips', {
-                    templateUrl: 'templates/panels/tips/tips-index.html',
-                    activetab: 'board'
-                })
 
             // If client doesn't hit an existing route, go to '/'
             .otherwise({

--- a/app/javascripts/services/interceptors.js
+++ b/app/javascripts/services/interceptors.js
@@ -28,9 +28,9 @@ angular.module("JHO")
                 },
 
                 responseError: function(res) {
-                    console.log("response error is: ", res);
-                    // if response to API is a 401
-                    $window.location.href = '#/login'
+                    console.log("interceptor responseError: server error / bad request: ", res);
+                    // if response to API is a 422 or 401
+                    return res;
                 }
             }
         }

--- a/app/stylesheets/main.css
+++ b/app/stylesheets/main.css
@@ -1,10 +1,4 @@
-.app-content {
-  height: 100px;
-  width: 100%;
-  border: 1px red solid;
-}
-
- Grid set up */
+/* Grid set up */
 .grid-container{
         width: 100%;
         margin: 0 auto;

--- a/app/templates/auth.html
+++ b/app/templates/auth.html
@@ -1,10 +1,10 @@
-<div ng-controller="AuthController as auth" ng-model="form">
+<div ng-controller="AuthController as auth" ng-if="!auth.isAuthed()" ng-model="form">
 <a href="#/login" ng-click="form = 'login'">Login</a>
 <a href="#/register" ng-click="form = 'register'">Register</a>
-<!-- ng-if="existingUser()" -->
+
   <section id="login" ng-show="form == 'login'">
     <h2>Login</h2>
-    <div class="login" >
+    <div class="login">
       <form novalidate ng-submit="auth.login(user)" name="loginForm">
         Email: <input required ng-model="user.email" type="text" name="user[email]">
         Password: <input required ng-model="user.password" type="password" name="user[password]">
@@ -12,10 +12,11 @@
       </form>
     </div>
   </section>
-  <!-- ng-if="newUser()" -->
+
     <h3>
       {{auth.message}}
     </h3>
+
   <section id="register" ng-show="form == 'register'">
     <h2>Register</h2>
     <div class="register">

--- a/app/templates/auth.html
+++ b/app/templates/auth.html
@@ -1,8 +1,8 @@
-<div ng-controller="AuthController as auth" ng-if="!auth.isAuthed()" ng-model="form">
-<a href="#/login" ng-click="form = 'login'">Login</a>
-<a href="#/register" ng-click="form = 'register'">Register</a>
+<div ng-controller="AuthController as auth" ng-model="form">
+<a href="#/auth" ng-click="form = 'login'">Login</a>
+<a href="#/auth" ng-click="form = 'register'">Register</a>
 
-  <section id="login" ng-show="form == 'login'">
+  <section id="login" ng-if="form == 'login'">
     <h2>Login</h2>
     <div class="login">
       <form novalidate ng-submit="auth.login(user)" name="loginForm">
@@ -17,7 +17,7 @@
       {{auth.message}}
     </h3>
 
-  <section id="register" ng-show="form == 'register'">
+  <section id="register" ng-if="form == 'register'">
     <h2>Register</h2>
     <div class="register">
       <form novalidate ng-submit="auth.register(user)" name="registerForm">

--- a/app/templates/auth.html
+++ b/app/templates/auth.html
@@ -1,5 +1,4 @@
 <div ng-controller="AuthController as auth" ng-model="form">
-<a href="#/logout" ng-if="auth.isAuthed()" ng-click="auth.logout()">Log out</a>
 <a href="#/login" ng-click="form = 'login'">Login</a>
 <a href="#/register" ng-click="form = 'register'">Register</a>
 <!-- ng-if="existingUser()" -->

--- a/app/templates/header.html
+++ b/app/templates/header.html
@@ -6,5 +6,6 @@
     <li><a href="#/welcome">Home</a></li>
     <li><a href="#/about">About</a></li>
     <li><a href="#/contact">Contact</a></li>
+    <li ng-if="auth.isAuthed()"><a href="#/logout"  ng-click="auth.logout()">Log out</a></li>
   </ul>
 </nav>

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -1,5 +1,6 @@
+<!-- Not being used - handling all logging in and registration through auth.html -->
 <div ng-controller="AuthController as auth">
-<!-- ng-if="existingUser()" -->
+<a href="#/register">Register</a>
   <section id="login">
     <h2>Login</h2>
     <div class="login">
@@ -10,7 +11,6 @@
       </form>
     </div>
   </section>
-  <!-- ng-if="newUser()" -->
     <small>
       {{auth.message}}
     </small>

--- a/app/templates/register.html
+++ b/app/templates/register.html
@@ -1,4 +1,6 @@
+<!-- Not being used - handling all logging in and registration through auth.html -->
 <div ng-controller="AuthController as auth">
+<a href="#/login">Login</a>
     <small>
       {{auth.message}}
     </small>
@@ -15,30 +17,3 @@
     </div>
   </section>
 </div>
-
-
-
-<!-- <h2>{{ title }}</h2>
-<div ng-controller="UsersController as usersCtrl" class="register">
-  <form novalidate ng-submit="usersCtrl.createUser(user)">
-    Name: <input ng-model="user.name" type="text" name="user[name]">
-    Email: <input ng-model="user.email" type="text" name="user[email]">
-    Password: <input ng-model="user.password" type="password" name="user[password]">
-    Password Confirmation: <input ng-model="user.password_confirmation" type="password" name="user[password_confirmation]">
-    <input type="submit" value="Register">
-  </form>
-</div>
-
-<hr>
-<hr> -->
-<!-- <div ng-controller="Main as main">
-    <h1>Simple Angular Auth - Thinkster</h1>
-
-    <input type="text" ng-model="main.username" placeholder="username"><br>
-    <input type="password" ng-model="main.password" placeholder="password"><br>
-    <br>
-
-    <button ng-click="main.register()">Register</button>
-    <button ng-click="main.login()">Login</button>
-    <button ng-click="main.logout()" ng-show="main.isAuthed()">Logout</button>
-</div> -->


### PR DESCRIPTION
Used `ng-if` to render or not render content based on if the user is logged in or not.
When a user logs in or registers sucessfully they are redirected to the `/board` route / template.
An unsuccessful login or registration submittion redirects them to the `/auth` route (which will need some additional form validation / tooltips to tell the user to fix whatever they did wrong).
Logging out causes the auth-reliant content to disappear and the auth navigation to render via `ng-if`.

Note: currently the login.html and register.html routes / pages are not being used. The reason for this is because we are using `auth.html` as an `ng-if`-based partial and reserving our `ng-view` directive for actual content (for example, a logged out user can view the welcome page). The login.html and register.html can't be accessed because  `ng-view` is dependent on the user being logged in, creating a catch-22 situation where those routes are visited but the content never rendered.

Long story short, we have a minimum viable way to keep users from accessing content that they need to be authenticated to see.
